### PR TITLE
fix(terraform): don't check encryption for DynamoDB tables in AVD-AWS-0023

### DIFF
--- a/rules/cloud/policies/aws/dynamodb/enable_at_rest_encryption.go
+++ b/rules/cloud/policies/aws/dynamodb/enable_at_rest_encryption.go
@@ -14,10 +14,10 @@ var CheckEnableAtRestEncryption = rules.Register(
 		Provider:    providers.AWSProvider,
 		Service:     "dynamodb",
 		ShortCode:   "enable-at-rest-encryption",
-		Summary:     "DAX Cluster and tables should always encrypt data at rest",
+		Summary:     "DAX Cluster should always encrypt data at rest",
 		Impact:      "Data can be freely read if compromised",
 		Resolution:  "Enable encryption at rest for DAX Cluster",
-		Explanation: `Amazon DynamoDB Accelerator (DAX) and table encryption at rest provides an additional layer of data protection by helping secure your data from unauthorized access to the underlying storage.`,
+		Explanation: `Amazon DynamoDB Accelerator (DAX) encryption at rest provides an additional layer of data protection by helping secure your data from unauthorized access to the underlying storage.`,
 		Links: []string{
 			"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAXEncryptionAtRest.html",
 			"https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html",
@@ -43,24 +43,11 @@ var CheckEnableAtRestEncryption = rules.Register(
 			}
 			if cluster.ServerSideEncryption.Enabled.IsFalse() {
 				results.Add(
-					"Table encryption is not enabled.",
+					"DAX encryption is not enabled.",
 					cluster.ServerSideEncryption.Enabled,
 				)
 			} else {
 				results.AddPassed(&cluster)
-			}
-		}
-		for _, table := range s.AWS.DynamoDB.Tables {
-			if table.Metadata.IsUnmanaged() {
-				continue
-			}
-			if table.ServerSideEncryption.Enabled.IsFalse() {
-				results.Add(
-					"Table encryption is not enabled.",
-					table.ServerSideEncryption.Enabled,
-				)
-			} else {
-				results.AddPassed(&table)
 			}
 		}
 		return


### PR DESCRIPTION
See https://github.com/aquasecurity/trivy/issues/5005

Encryption at rest is always [enabled](https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/client-server-side.html) for DynamoDB tables.
>DynamoDB transparently encrypts and decrypts all tables when they are written. There is no option to enable or disable encryption at rest.