### PR TITLE
fix(terraform): improve AVD-AWS-0025 rule

### DIFF
--- a/rules/cloud/policies/aws/dynamodb/table_customer_key.go
+++ b/rules/cloud/policies/aws/dynamodb/table_customer_key.go
@@ -35,12 +35,13 @@ var CheckTableCustomerKey = rules.Register(
 			if table.Metadata.IsUnmanaged() {
 				continue
 			}
-			if table.ServerSideEncryption.KMSKeyID.IsEmpty() {
+			if table.ServerSideEncryption.Enabled.IsFalse() {
 				results.Add(
 					"Table encryption does not use a customer-managed KMS key.",
 					table.ServerSideEncryption.KMSKeyID,
 				)
-			} else if table.ServerSideEncryption.KMSKeyID.EqualTo(dynamodb.DefaultKMSKeyID) {
+			} else if table.ServerSideEncryption.KMSKeyID.IsEmpty() ||
+				table.ServerSideEncryption.KMSKeyID.EqualTo(dynamodb.DefaultKMSKeyID) {
 				results.Add(
 					"Table encryption explicitly uses the default KMS key.",
 					table.ServerSideEncryption.KMSKeyID,

--- a/rules/cloud/policies/aws/dynamodb/table_customer_key.go
+++ b/rules/cloud/policies/aws/dynamodb/table_customer_key.go
@@ -31,24 +31,6 @@ var CheckTableCustomerKey = rules.Register(
 		Severity: severity.Low,
 	},
 	func(s *state.State) (results scan.Results) {
-		for _, cluster := range s.AWS.DynamoDB.DAXClusters {
-			if cluster.Metadata.IsUnmanaged() {
-				continue
-			}
-			if cluster.ServerSideEncryption.KMSKeyID.IsEmpty() {
-				results.Add(
-					"Cluster encryption does not use a customer-managed KMS key.",
-					cluster.ServerSideEncryption.KMSKeyID,
-				)
-			} else if cluster.ServerSideEncryption.KMSKeyID.EqualTo(dynamodb.DefaultKMSKeyID) {
-				results.Add(
-					"Cluster encryption explicitly uses the default KMS key.",
-					cluster.ServerSideEncryption.KMSKeyID,
-				)
-			} else {
-				results.AddPassed(&cluster)
-			}
-		}
 		for _, table := range s.AWS.DynamoDB.Tables {
 			if table.Metadata.IsUnmanaged() {
 				continue


### PR DESCRIPTION
1. DAX encryption [uses](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAXEncryptionAtRest.html) AWS KMS by default and this cannot be changed.
2. We should only check custom KMS if SSE is enabled otherwise AWS [uses](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html) its own key.