### PR TITLE
fix(google): do not check flow logs on proxy-only subnets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,3 +112,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/aquasecurity/defsec => github.com/nikpivkin/defsec v0.0.0-20231114064640-57d79a56ec8f

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/trivy-policies
 go 1.20
 
 require (
-	github.com/aquasecurity/defsec v0.93.2-0.20231024055158-015ab97ce898
+	github.com/aquasecurity/defsec v0.93.2-0.20231115015625-adcb9e5799e5
 	github.com/aquasecurity/trivy-iac v0.5.2
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/liamg/iamgo v0.0.9
@@ -112,5 +112,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/aquasecurity/defsec => github.com/nikpivkin/defsec v0.0.0-20231114064640-57d79a56ec8f

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/aquasecurity/defsec v0.93.2-0.20231024055158-015ab97ce898 h1:gu7XQvv2CswgzOdOFHg/AmtR4vBonG35XvGxHHvcIr4=
-github.com/aquasecurity/defsec v0.93.2-0.20231024055158-015ab97ce898/go.mod h1:J30VViSgmoW2Ic/6aqVJO2qvuADsmZ3MYuNxPcU6Vt0=
 github.com/aquasecurity/trivy-iac v0.5.2 h1:cqeSDEfQtM3l4ceiQ+IUD2K/ZBhyz443xe+S2TkBdE0=
 github.com/aquasecurity/trivy-iac v0.5.2/go.mod h1:dHoaIzm4niotuaEiSM40HelhcL8m/2MHzT3uHcQYUh8=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
@@ -175,6 +173,8 @@ github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nikpivkin/defsec v0.0.0-20231114064640-57d79a56ec8f h1:QszuEXSftNdl5VIkUQ8cvLRk8+LGN8kw6/DsyWu6o9A=
+github.com/nikpivkin/defsec v0.0.0-20231114064640-57d79a56ec8f/go.mod h1:J30VViSgmoW2Ic/6aqVJO2qvuADsmZ3MYuNxPcU6Vt0=
 github.com/open-policy-agent/opa v0.57.0 h1:DftxYfOEHOheXvO2Q6HCIM2ZVdKrvnF4cZlU9C64MIQ=
 github.com/open-policy-agent/opa v0.57.0/go.mod h1:3FY6GNSbUqOhjCdvTXCBJ2rNuh66p/XrIc2owr/hSwo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
+github.com/aquasecurity/defsec v0.93.2-0.20231115015625-adcb9e5799e5 h1:CkfFZpctJrH+oHWlvuAE2qV4DNDqaVtPlEkVksbwuwo=
+github.com/aquasecurity/defsec v0.93.2-0.20231115015625-adcb9e5799e5/go.mod h1:J30VViSgmoW2Ic/6aqVJO2qvuADsmZ3MYuNxPcU6Vt0=
 github.com/aquasecurity/trivy-iac v0.5.2 h1:cqeSDEfQtM3l4ceiQ+IUD2K/ZBhyz443xe+S2TkBdE0=
 github.com/aquasecurity/trivy-iac v0.5.2/go.mod h1:dHoaIzm4niotuaEiSM40HelhcL8m/2MHzT3uHcQYUh8=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
@@ -173,8 +175,6 @@ github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nikpivkin/defsec v0.0.0-20231114064640-57d79a56ec8f h1:QszuEXSftNdl5VIkUQ8cvLRk8+LGN8kw6/DsyWu6o9A=
-github.com/nikpivkin/defsec v0.0.0-20231114064640-57d79a56ec8f/go.mod h1:J30VViSgmoW2Ic/6aqVJO2qvuADsmZ3MYuNxPcU6Vt0=
 github.com/open-policy-agent/opa v0.57.0 h1:DftxYfOEHOheXvO2Q6HCIM2ZVdKrvnF4cZlU9C64MIQ=
 github.com/open-policy-agent/opa v0.57.0/go.mod h1:3FY6GNSbUqOhjCdvTXCBJ2rNuh66p/XrIc2owr/hSwo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/rules/cloud/policies/google/compute/enable_vpc_flow_logs.go
+++ b/rules/cloud/policies/google/compute/enable_vpc_flow_logs.go
@@ -30,7 +30,10 @@ var CheckEnableVPCFlowLogs = rules.Register(
 	func(s *state.State) (results scan.Results) {
 		for _, network := range s.Google.Compute.Networks {
 			for _, subnetwork := range network.Subnetworks {
-				if subnetwork.EnableFlowLogs.IsFalse() {
+				if subnetwork.EnableFlowLogs.IsFalse() &&
+					// Proxy-only subnets don't support VPC Flow Logs.
+					// https://cloud.google.com/vpc/docs/using-flow-logs#flow_logs_appear_to_be_disabled_even_though_you_enabled_them
+					!subnetwork.Purpose.IsOneOf("REGIONAL_MANAGED_PROXY", "GLOBAL_MANAGED_PROXY") {
 					results.Add(
 						"Subnetwork does not have VPC flow logs enabled.",
 						subnetwork.EnableFlowLogs,

--- a/rules/cloud/policies/google/compute/enable_vpc_flow_logs_test.go
+++ b/rules/cloud/policies/google/compute/enable_vpc_flow_logs_test.go
@@ -53,6 +53,24 @@ func TestCheckEnableVPCFlowLogs(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "Proxy-only subnets and logs disabled",
+			input: compute.Compute{
+				Networks: []compute.Network{
+					{
+						Metadata: defsecTypes.NewTestMetadata(),
+						Subnetworks: []compute.SubNetwork{
+							{
+								Metadata:       defsecTypes.NewTestMetadata(),
+								EnableFlowLogs: defsecTypes.BoolDefault(false, defsecTypes.NewTestMetadata()),
+								Purpose:        defsecTypes.String("REGIONAL_MANAGED_PROXY", defsecTypes.NewTestMetadata()),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Proxy-only subnets don't support [VPC Flow Logs](https://cloud.google.com/vpc/docs/using-flow-logs).

Ref:
- https://cloud.google.com/load-balancing/docs/proxy-only-subnets#limitations
- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork#log_config

### Related PRs:
- [x] https://github.com/aquasecurity/defsec/pull/1494