### PR TITLE
feat(aws): improve AVD-AWS-0013 rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/trivy-policies
 go 1.20
 
 require (
-	github.com/aquasecurity/defsec v0.93.2-0.20231024055158-015ab97ce898
+	github.com/aquasecurity/defsec v0.93.2-0.20231115015625-adcb9e5799e5
 	github.com/aquasecurity/trivy-iac v0.5.2
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/liamg/iamgo v0.0.9
@@ -112,5 +112,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/aquasecurity/defsec => github.com/nikpivkin/defsec v0.0.0-20231114084431-b974397eaa64

--- a/go.mod
+++ b/go.mod
@@ -112,3 +112,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/aquasecurity/defsec => github.com/nikpivkin/defsec v0.0.0-20231114084431-b974397eaa64

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/aquasecurity/defsec v0.93.2-0.20231024055158-015ab97ce898 h1:gu7XQvv2CswgzOdOFHg/AmtR4vBonG35XvGxHHvcIr4=
-github.com/aquasecurity/defsec v0.93.2-0.20231024055158-015ab97ce898/go.mod h1:J30VViSgmoW2Ic/6aqVJO2qvuADsmZ3MYuNxPcU6Vt0=
 github.com/aquasecurity/trivy-iac v0.5.2 h1:cqeSDEfQtM3l4ceiQ+IUD2K/ZBhyz443xe+S2TkBdE0=
 github.com/aquasecurity/trivy-iac v0.5.2/go.mod h1:dHoaIzm4niotuaEiSM40HelhcL8m/2MHzT3uHcQYUh8=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
@@ -175,6 +173,8 @@ github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nikpivkin/defsec v0.0.0-20231114084431-b974397eaa64 h1:UzXsfnEuDKXOABg73/b4dYTSxbC/KmRMqNS7HEh/aVY=
+github.com/nikpivkin/defsec v0.0.0-20231114084431-b974397eaa64/go.mod h1:J30VViSgmoW2Ic/6aqVJO2qvuADsmZ3MYuNxPcU6Vt0=
 github.com/open-policy-agent/opa v0.57.0 h1:DftxYfOEHOheXvO2Q6HCIM2ZVdKrvnF4cZlU9C64MIQ=
 github.com/open-policy-agent/opa v0.57.0/go.mod h1:3FY6GNSbUqOhjCdvTXCBJ2rNuh66p/XrIc2owr/hSwo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
+github.com/aquasecurity/defsec v0.93.2-0.20231115015625-adcb9e5799e5 h1:CkfFZpctJrH+oHWlvuAE2qV4DNDqaVtPlEkVksbwuwo=
+github.com/aquasecurity/defsec v0.93.2-0.20231115015625-adcb9e5799e5/go.mod h1:J30VViSgmoW2Ic/6aqVJO2qvuADsmZ3MYuNxPcU6Vt0=
 github.com/aquasecurity/trivy-iac v0.5.2 h1:cqeSDEfQtM3l4ceiQ+IUD2K/ZBhyz443xe+S2TkBdE0=
 github.com/aquasecurity/trivy-iac v0.5.2/go.mod h1:dHoaIzm4niotuaEiSM40HelhcL8m/2MHzT3uHcQYUh8=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
@@ -173,8 +175,6 @@ github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nikpivkin/defsec v0.0.0-20231114084431-b974397eaa64 h1:UzXsfnEuDKXOABg73/b4dYTSxbC/KmRMqNS7HEh/aVY=
-github.com/nikpivkin/defsec v0.0.0-20231114084431-b974397eaa64/go.mod h1:J30VViSgmoW2Ic/6aqVJO2qvuADsmZ3MYuNxPcU6Vt0=
 github.com/open-policy-agent/opa v0.57.0 h1:DftxYfOEHOheXvO2Q6HCIM2ZVdKrvnF4cZlU9C64MIQ=
 github.com/open-policy-agent/opa v0.57.0/go.mod h1:3FY6GNSbUqOhjCdvTXCBJ2rNuh66p/XrIc2owr/hSwo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/rules/cloud/policies/aws/cloudfront/use_secure_tls_policy_test.go
+++ b/rules/cloud/policies/aws/cloudfront/use_secure_tls_policy_test.go
@@ -28,6 +28,7 @@ func TestCheckUseSecureTlsPolicy(t *testing.T) {
 						ViewerCertificate: cloudfront.ViewerCertificate{
 							Metadata:               defsecTypes.NewTestMetadata(),
 							MinimumProtocolVersion: defsecTypes.String("TLSv1.0", defsecTypes.NewTestMetadata()),
+							SSLSupportMethod:       defsecTypes.String("sni-only", defsecTypes.NewTestMetadata()),
 						},
 					},
 				},
@@ -43,6 +44,38 @@ func TestCheckUseSecureTlsPolicy(t *testing.T) {
 						ViewerCertificate: cloudfront.ViewerCertificate{
 							Metadata:               defsecTypes.NewTestMetadata(),
 							MinimumProtocolVersion: defsecTypes.String(cloudfront.ProtocolVersionTLS1_2, defsecTypes.NewTestMetadata()),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "CloudFrontDefaultCertificate is true",
+			input: cloudfront.Cloudfront{
+				Distributions: []cloudfront.Distribution{
+					{
+						Metadata: defsecTypes.NewTestMetadata(),
+						ViewerCertificate: cloudfront.ViewerCertificate{
+							Metadata:                     defsecTypes.NewTestMetadata(),
+							MinimumProtocolVersion:       defsecTypes.String("TLSv1.0", defsecTypes.NewTestMetadata()),
+							CloudfrontDefaultCertificate: defsecTypes.Bool(true, defsecTypes.NewTestMetadata()),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "SSLSupportMethod is not `sny-only`",
+			input: cloudfront.Cloudfront{
+				Distributions: []cloudfront.Distribution{
+					{
+						Metadata: defsecTypes.NewTestMetadata(),
+						ViewerCertificate: cloudfront.ViewerCertificate{
+							Metadata:               defsecTypes.NewTestMetadata(),
+							MinimumProtocolVersion: defsecTypes.String("TLSv1.0", defsecTypes.NewTestMetadata()),
+							SSLSupportMethod:       defsecTypes.String("vip", defsecTypes.NewTestMetadata()),
 						},
 					},
 				},


### PR DESCRIPTION
The user can set security policies (minimum_protocol_version) if `CloudFrontDefaultCertificate` is false and `SSLSupportMethod` is `sni-only`

Ref:
- https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesGeneral

Related PRs:
- [x] https://github.com/aquasecurity/defsec/pull/1495