### PR TITLE
chore: downgrade Go to 1.19 for commercial

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/trivy-policies
 
-go 1.20
+go 1.19
 
 require (
 	github.com/aquasecurity/defsec v0.93.2-0.20231024055158-015ab97ce898


### PR DESCRIPTION
### Related PRs:
- [ ] https://github.com/aquasecurity/defsec/pull/1497