### PR TITLE
feat(digitalocean): improve AVD-AWS-0012 rule

### DIFF
--- a/checks/cloud/digitalocean/compute/enforce_https.go
+++ b/checks/cloud/digitalocean/compute/enforce_https.go
@@ -33,6 +33,9 @@ You should use HTTPS, which is HTTP over an encrypted (TLS) connection, meaning 
 	},
 	func(s *state.State) (results scan.Results) {
 		for _, lb := range s.DigitalOcean.Compute.LoadBalancers {
+			if lb.RedirectHttpToHttps.IsTrue() {
+				continue
+			}
 			for _, rule := range lb.ForwardingRules {
 				if rule.EntryProtocol.EqualTo("http") {
 					results.Add(

--- a/checks/cloud/digitalocean/compute/enforce_https_test.go
+++ b/checks/cloud/digitalocean/compute/enforce_https_test.go
@@ -53,6 +53,24 @@ func TestCheckEnforceHttps(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "Load balancer forwarding rule using HTTP, but HTTP redirection to HTTPS is enabled",
+			input: compute.Compute{
+				LoadBalancers: []compute.LoadBalancer{
+					{
+						Metadata:            defsecTypes.NewTestMetadata(),
+						RedirectHttpToHttps: defsecTypes.Bool(true, defsecTypes.NewTestMetadata()),
+						ForwardingRules: []compute.ForwardingRule{
+							{
+								Metadata:      defsecTypes.NewTestMetadata(),
+								EntryProtocol: defsecTypes.String("http", defsecTypes.NewTestMetadata()),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/trivy-policies
 go 1.20
 
 require (
-	github.com/aquasecurity/defsec v0.93.2-0.20231209043331-6c7b9811ed2a
+	github.com/aquasecurity/defsec v0.93.2-0.20240104002958-968b8f115bc0
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/liamg/iamgo v0.0.9
 	github.com/liamg/memoryfs v1.6.0
@@ -88,5 +88,3 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/aquasecurity/defsec => /Users/nikita/projects/defsec

--- a/go.mod
+++ b/go.mod
@@ -88,3 +88,5 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/aquasecurity/defsec => /Users/nikita/projects/defsec

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/aquasecurity/defsec v0.93.2-0.20231209043331-6c7b9811ed2a h1:88tMKS0nhQwhcouVkqDNgOZ40qvPodpWE/uOqgHBOnw=
-github.com/aquasecurity/defsec v0.93.2-0.20231209043331-6c7b9811ed2a/go.mod h1:NBF6hvbQSc4s/WCHdKV5sNNxLl258M2OiIFoUfgEn/k=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
+github.com/aquasecurity/defsec v0.93.2-0.20240104002958-968b8f115bc0 h1:K4XwF6joBVlGFtu78TzbhmsRNVojYTWANJWDeqXs50Y=
+github.com/aquasecurity/defsec v0.93.2-0.20240104002958-968b8f115bc0/go.mod h1:NBF6hvbQSc4s/WCHdKV5sNNxLl258M2OiIFoUfgEn/k=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=


### PR DESCRIPTION
See https://github.com/aquasecurity/trivy/issues/5111

Now if `redirect_http_to_https` is enabled, the rule does not warn about using HTTP in the load balancer

### Related PRs:
- [x] https://github.com/aquasecurity/defsec/pull/1507