### PR TITLE
fix: fail for irrelevant resources

### DIFF
--- a/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID.rego
+++ b/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID.rego
@@ -59,6 +59,7 @@ failRootGroupId {
 }
 
 deny[res] {
+	failRootGroupId
 	output := failRootGroupId
 	msg := kubernetes.format(sprintf("%s %s in %s namespace should set spec.securityContext.runAsGroup, spec.securityContext.supplementalGroups[*] and spec.securityContext.fsGroup to integer greater than 0", [lower(kubernetes.kind), kubernetes.name, kubernetes.namespace]))
 	res := result.new(msg, output)

--- a/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID_test.rego
+++ b/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID_test.rego
@@ -27,5 +27,15 @@ test_failRootGroupId_failed {
 		}},
 	}
 
-	count(r) > 0
+	count(r) = 0
+}
+
+test_failRootGroupId_irrelevant {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "ClusterRole",
+		"metadata": {"name": "hello"}
+	}
+
+	count(r) = 0	
 }

--- a/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID_test.rego
+++ b/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID_test.rego
@@ -34,8 +34,8 @@ test_failRootGroupId_irrelevant {
 	r := deny with input as {
 		"apiVersion": "v1",
 		"kind": "ClusterRole",
-		"metadata": {"name": "hello"}
+		"metadata": {"name": "hello"},
 	}
 
-	count(r) = 0	
+	count(r) = 0
 }


### PR DESCRIPTION
reported in https://github.com/aquasecurity/trivy/issues/4922 since the failRootGroupId rule is given a default value, it doesn't fail the deny rule and results in a false detection. added an explicit check for the failRootGropuId truthiness to resolve.

also fixed the sad path test
however I'm not sure how we're supposed to run the tests and if it's indeed broken