### PR TITLE
fix(checks): Use correct input for AVD-KSV-01010

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,7 @@ fmt-rego:
 	opa fmt -w rules/
 
 .PHONY: bundle
-bundle:
-	./scripts/bundle.sh
-	cp bundle.tar.gz scripts/bundle.tar.gz
-	go run ./scripts/verify-bundle.go
-	rm scripts/bundle.tar.gz
+bundle: create-bundle verify-bundle
 
 .PHONY: id
 id:
@@ -33,3 +29,13 @@ docs:
 .PHONY: docs-test
 docs-test:
 	go test -v ./cmd/avd_generator/...
+
+.PHONY: create-bundle
+create-bundle:
+	./scripts/bundle.sh
+
+.PHONY: verify-bundle
+verify-bundle:
+	cp bundle.tar.gz scripts/bundle.tar.gz
+	go run ./scripts/verify-bundle.go
+	rm scripts/bundle.tar.gz

--- a/checks/kubernetes/aquacommercial/configmap_with_sensitive.rego
+++ b/checks/kubernetes/aquacommercial/configmap_with_sensitive.rego
@@ -93,7 +93,7 @@ ConfigMapWithSensitive[sensitiveData] {
 
 ConfigMapWithSensitive[sensitiveData] {
 	input.kind == "ConfigMap"
-	values = split(input.data[d], "\n")
+	values = split(kubernetes.object.data[d], "\n")
 	val = split(values[v], ":")
 	regex.match(patternForIbanAndPassport[p], val[v])
 	sensitiveData = d


### PR DESCRIPTION
Fixes the following issue

```shell
2024-01-13T14:25:34.160-0700    DEBUG   [misconf] 25:34.160914000 terraform.scanner.rego           Error occurred while parsing: Users/s/Library/Caches/trivy/policy/content/policies/kubernetes/policies/aquacommercial/configmap_with_sensitive.rego, Users/s/Library/Caches/trivy/policy/content/policies/kubernetes/policies/aquacommercial/configmap_with_sensitive.rego:96: rego_type_error: undefined ref: input.data[d]
        input.data[d]
              ^
              have: "data"
              want (one of): ["apiVersion" "kind" "metadata" "rules" "spec"]
```