### PR TITLE
fix(checks): handle `file:` and `multi:` in AVD-DS-0011

### DIFF
--- a/checks/docker/copy_with_more_than_two_arguments_not_ending_with_slash.rego
+++ b/checks/docker/copy_with_more_than_two_arguments_not_ending_with_slash.rego
@@ -25,12 +25,21 @@ get_copy_arg[output] {
 	cnt := count(copy.Value)
 	cnt > 2
 
+	not is_command_with_hash(copy.Value, "file:")
+	not is_command_with_hash(copy.Value, "multi:")
+
 	arg := copy.Value[cnt - 1]
 	not endswith(arg, "/")
 	output := {
 		"arg": arg,
 		"cmd": copy,
 	}
+}
+
+is_command_with_hash(cmd, prefix) {
+	count(cmd) == 3
+	startswith(cmd[0], prefix)
+	cmd[1] == "in"
 }
 
 deny[res] {

--- a/checks/docker/copy_with_more_than_two_arguments_not_ending_with_slash_test.rego
+++ b/checks/docker/copy_with_more_than_two_arguments_not_ending_with_slash_test.rego
@@ -31,6 +31,36 @@ test_two_args_allowed {
 	count(r) == 0
 }
 
+test_three_args_with_file_colon_in_allowed {
+	r := deny with input as {"Stages": [{"Name": "alpine:3.3", "Commands": [
+		{
+			"Cmd": "from",
+			"Value": ["node:carbon2"],
+		},
+		{
+			"Cmd": "copy",
+			"Value": ["file:8b8864b3e02a33a579dc216fd51b28a6047bc8eeaa03045b258980fe0cf7fcb3", "in", "myfile"],
+		},
+	]}]}
+
+	count(r) == 0
+}
+
+test_three_args_with_multi_colon_in_allowed {
+	r := deny with input as {"Stages": [{"Name": "alpine:3.3", "Commands": [
+		{
+			"Cmd": "from",
+			"Value": ["node:carbon2"],
+		},
+		{
+			"Cmd": "copy",
+			"Value": ["multi:8b8864b3e02a33a579dc216fd51b28a6047bc8eeaa03045b258980fe0cf7fcb3", "in", "myfile"],
+		},
+	]}]}
+
+	count(r) == 0
+}
+
 test_three_arg_allowed {
 	r := deny with input as {"Stages": [{"Name": "alpine:3.3", "Commands": [
 		{


### PR DESCRIPTION
The reverse engineered `Dockerfile` of an image doesn't exactly match
the original `Dockerfile`. For example, it doesn't have the original
source files names. Instead, it uses `file:<hash> in`:
`COPY file:8b8864b3e02a33a579dc216fd51b28a6047bc8eeaa03045b258980fe0cf7fcb3 in /__cacert_entrypoint.sh`

Such commands should not trigger AVD-DS-0011.
