### PR TITLE
fix: remove test-rego from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	go test -v ./...
 
 .PHONY: rego
-rego: fmt-rego test-rego
+rego: fmt-rego
 
 .PHONY: fmt-rego
 fmt-rego:


### PR DESCRIPTION
e339a0d removed the `test-rego` rule so references to it should also be removed.