### PR TITLE
fix(checks): handle `file:` and `multi:` in AVD-DS-005

### DIFF
--- a/checks/docker/add_instead_of_copy.rego
+++ b/checks/docker/add_instead_of_copy.rego
@@ -24,10 +24,20 @@ get_add[output] {
 	args := concat(" ", add.Value)
 
 	not contains(args, ".tar")
+
+	not is_command_with_hash(add.Value, "file:")
+	not is_command_with_hash(add.Value, "multi:")
+
 	output := {
 		"args": args,
 		"cmd": add,
 	}
+}
+
+is_command_with_hash(cmd, prefix) {
+	count(cmd) == 3
+	startswith(cmd[0], prefix)
+	cmd[1] == "in"
 }
 
 deny[res] {

--- a/checks/docker/add_instead_of_copy_test.rego
+++ b/checks/docker/add_instead_of_copy_test.rego
@@ -44,6 +44,24 @@ test_copy_allowed {
 	count(r) == 0
 }
 
+test_add_file_colon_in_allowed {
+	r := deny with input as {"Stages": [{
+		"Name": "alpine:3.13",
+		"Commands": [{"Cmd": "add", "Value": ["file:8b8864b3e02a33a579dc216fd51b28a6047bc8eeaa03045b258980fe0cf7fcb3", "in", "/xyz"]}],
+	}]}
+
+	count(r) == 0
+}
+
+test_add_multi_colon_in_allowed {
+	r := deny with input as {"Stages": [{
+		"Name": "alpine:3.13",
+		"Commands": [{"Cmd": "add", "Value": ["multi:8b8864b3e02a33a579dc216fd51b28a6047bc8eeaa03045b258980fe0cf7fcb3", "in", "/xyz"]}],
+	}]}
+
+	count(r) == 0
+}
+
 test_add_tar_allowed {
 	r := deny with input as {"Stages": [{
 		"Name": "alpine:3.13",


### PR DESCRIPTION
The reverse engineered `Dockerfile` of an image doesn't exactly match the original `Dockerfile`. For example, it doesn't have the original source files names. Instead, it uses `file:<hash> in`: `ADD file:8b8864b3e02a33a579dc216fd51b28a6047bc8eeaa03045b258980fe0cf7fcb3 in /__cacert_entrypoint.sh`

Such commands should not trigger AVD-DS-005.