### PR TITLE
fix: add system authenticate bind protection policy

### DIFF
--- a/avd_docs/kubernetes/gke/AVD-KSV-01011/docs.md
+++ b/avd_docs/kubernetes/gke/AVD-KSV-01011/docs.md
@@ -1,0 +1,10 @@
+
+Binding to system:authenticate group to any clusterrole or role is a security risk.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+

--- a/checks/kubernetes/gke/authenticate_group_bind.rego
+++ b/checks/kubernetes/gke/authenticate_group_bind.rego
@@ -1,0 +1,39 @@
+# METADATA
+# title: "system:authenticate group access binding"
+# description: "Binding to system:authenticate group to any clusterrole or role is a security risk."
+# scope: package
+# schemas:
+# - input: schema["kubernetes"]
+# related_resources:
+# - https://orca.security/resources/blog/sys-all-google-kubernetes-engine-risk/
+# custom:
+#   id: KSV01011
+#   avd_id: AVD-KSV-01011
+#   severity: CRITICAL
+#   short_code: no-system-authenticated-group-bind
+#   recommended_action: "Remove system:authenticated group binding from clusterrolebinding or rolebinding."
+#   input:
+#     selector:
+#     - type: kubernetes
+#       subtypes:
+#         - kind: rolebinding
+#         - kind: clusterrolebinding
+
+package appshield.kubernetes.KSV01011
+
+import data.lib.kubernetes
+
+readRoleRefs := ["system:authenticated"]
+
+readKinds := ["RoleBinding", "ClusterRolebinding"]
+
+authenticatedGroupBind(roleBinding) {
+	kubernetes.kind == readKinds[_]
+	kubernetes.object.subjects[_].name == readRoleRefs[_]
+}
+
+deny[res] {
+	authenticatedGroupBind(input)
+	msg := kubernetes.format(sprintf("%s '%s' should not bind to roles %s", [kubernetes.kind, kubernetes.name, readRoleRefs]))
+	res := result.new(msg, input.metadata)
+}

--- a/checks/kubernetes/gke/authenticate_group_bind_test.rego
+++ b/checks/kubernetes/gke/authenticate_group_bind_test.rego
@@ -1,0 +1,111 @@
+package appshield.kubernetes.KSV01011
+
+# Test case for a RoleBinding with system_authenticated user binding
+test_role_binding_with_system_authenticated_group_binding {
+	r := deny with input as {
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind": "RoleBinding",
+		"metadata": {
+			"name": "roleGroup",
+			"namespace": "default",
+		},
+		"subjects": [
+			{
+				"kind": "Group",
+				"name": "system:authenticated",
+				"apiGroup": "rbac.authorization.k8s.io",
+			},
+			{
+				"kind": "User",
+				"name": "system:anonymous",
+				"apiGroup": "rbac.authorization.k8s.io",
+			},
+		],
+		"roleRef": {
+			"kind": "Role",
+			"name": "some-role",
+			"apiGroup": "rbac.authorization.k8s.io",
+		},
+	}
+
+	count(r) == 1
+}
+
+#Test case for a ClusterRoleBinding with system:authenticated group binding
+test_cluster_role_binding_with_system_authenticate_binding {
+	r := deny with input as {
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind": "ClusterRolebinding",
+		"metadata": {
+			"name": "clusterRoleGroup",
+			"namespace": "default",
+		},
+		"subjects": [
+			{
+				"kind": "Group",
+				"name": "system:authenticated",
+				"apiGroup": "rbac.authorization.k8s.io",
+			},
+			{
+				"kind": "User",
+				"name": "system:anonymous",
+				"apiGroup": "rbac.authorization.k8s.io",
+			},
+		],
+		"roleRef": {
+			"kind": "ClusterRole",
+			"name": "clusterrole",
+			"apiGroup": "rbac.authorization.k8s.io",
+		},
+	}
+
+	count(r) == 1
+}
+
+# Test case for a RoleBinding with non system_authenticated group binding
+test_role_binding_with_non_system_authenticated_binding {
+	r := deny with input as {
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind": "RoleBinding",
+		"metadata": {
+			"name": "nonRole",
+			"namespace": "default",
+		},
+		"subjects": {
+			"kind": "Group",
+			"name": "system:unauthenticated",
+			"apiGroup": "rbac.authorization.k8s.io",
+		},
+		"roleRef": {
+			"kind": "Role",
+			"name": "role",
+			"apiGroup": "rbac.authorization.k8s.io",
+		},
+	}
+
+	count(r) == 0
+}
+
+# Test case for a ClusterRoleBinding with non system_authenticated group binding
+test_cluster_role_binding_with_non_system_authenticated_group_binding {
+	r := deny with input as {
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind": "ClusterRoleBinding",
+		"metadata": {
+			"name": "non_anonymous_user",
+			"namespace": "default",
+		},
+		"subjects": {
+			"kind": "Group",
+			"name": "system:unauthenticated",
+			"apiGroup": "rbac.authorization.k8s.io",
+		},
+		"roleRef": {
+			"kind": "ClusterRole",
+			"name": "clusterrole",
+			"apiGroup": "rbac.authorization.k8s.io",
+		},
+	}
+
+	count(r) == 0
+}


### PR DESCRIPTION
Following to security risk raised on [system:authenticate ](https://orca.security/resources/blog/sys-all-google-kubernetes-engine-risk/) adding a new policy to handle this case