### PR TITLE
chore: restore the OPA installation

### DIFF
--- a/.github/workflows/test-rego.yaml
+++ b/.github/workflows/test-rego.yaml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup OPA
+        uses: ./.github/actions/setup-opa
+
       - name: OPA Format
         run: |
           files=$(opa fmt --list . | grep -v vendor || true)


### PR DESCRIPTION
OPA is required for the formatting check step