### PR TITLE
fix: apply policy for gke provider only

### DIFF
--- a/checks/kubernetes/gke/authenticate_group_bind.rego
+++ b/checks/kubernetes/gke/authenticate_group_bind.rego
@@ -9,7 +9,7 @@
 # custom:
 #   id: KSV01011
 #   avd_id: AVD-KSV-01011
-#   severity: LOW
+#   severity: CRITICAL
 #   short_code: no-system-authenticated-group-bind
 #   recommended_action: "Remove system:authenticated group binding from clusterrolebinding or rolebinding."
 #   input:
@@ -21,6 +21,7 @@
 
 package appshield.kubernetes.KSV01011
 
+import data.k8s
 import data.lib.kubernetes
 
 readRoleRefs := ["system:authenticated"]
@@ -33,6 +34,7 @@ authenticatedGroupBind(roleBinding) {
 }
 
 deny[res] {
+	contains(k8s.version, "-gke")
 	authenticatedGroupBind(input)
 	msg := kubernetes.format(sprintf("%s '%s' should not bind to roles %s", [kubernetes.kind, kubernetes.name, readRoleRefs]))
 	res := result.new(msg, input.metadata)

--- a/checks/kubernetes/gke/authenticate_group_bind_test.rego
+++ b/checks/kubernetes/gke/authenticate_group_bind_test.rego
@@ -1,5 +1,9 @@
 package appshield.kubernetes.KSV01011
 
+k8sGke := "1.27.1-gke.1000"
+
+k8sNonGke := "1.27.1"
+
 # Test case for a RoleBinding with system_authenticated user binding
 test_role_binding_with_system_authenticated_group_binding {
 	r := deny with input as {
@@ -27,6 +31,7 @@ test_role_binding_with_system_authenticated_group_binding {
 			"apiGroup": "rbac.authorization.k8s.io",
 		},
 	}
+		with data.k8s.version as k8sGke
 
 	count(r) == 1
 }
@@ -58,7 +63,7 @@ test_cluster_role_binding_with_system_authenticate_binding {
 			"apiGroup": "rbac.authorization.k8s.io",
 		},
 	}
-
+		with data.k8s.version as k8sGke
 	count(r) == 1
 }
 
@@ -82,6 +87,7 @@ test_role_binding_with_non_system_authenticated_binding {
 			"apiGroup": "rbac.authorization.k8s.io",
 		},
 	}
+		with data.k8s.version as k8sGke
 
 	count(r) == 0
 }
@@ -106,6 +112,38 @@ test_cluster_role_binding_with_non_system_authenticated_group_binding {
 			"apiGroup": "rbac.authorization.k8s.io",
 		},
 	}
+		with data.k8s.version as k8sGke
+
+	count(r) == 0
+}
+
+test_role_binding_with_system_authenticated_group_binding_non_gke {
+	r := deny with input as {
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind": "RoleBinding",
+		"metadata": {
+			"name": "roleGroup",
+			"namespace": "default",
+		},
+		"subjects": [
+			{
+				"kind": "Group",
+				"name": "system:authenticated",
+				"apiGroup": "rbac.authorization.k8s.io",
+			},
+			{
+				"kind": "User",
+				"name": "system:anonymous",
+				"apiGroup": "rbac.authorization.k8s.io",
+			},
+		],
+		"roleRef": {
+			"kind": "Role",
+			"name": "some-role",
+			"apiGroup": "rbac.authorization.k8s.io",
+		},
+	}
+		with data.k8s.version as k8sNonGke
 
 	count(r) == 0
 }


### PR DESCRIPTION
## Description 
this change will:
1. apply policy on GKE cluster only
2. update policy severity to `CRITICAL`

- Related #65 