### PR TITLE
fix(aws): don't check SSLSupportMethod in AVD-AWS-0013

### DIFF
--- a/checks/cloud/aws/cloudfront/use_secure_tls_policy.go
+++ b/checks/cloud/aws/cloudfront/use_secure_tls_policy.go
@@ -20,7 +20,7 @@ var CheckUseSecureTlsPolicy = rules.Register(
 		Resolution: "Use the most modern TLS/SSL policies available",
 		Explanation: `You should not use outdated/insecure TLS versions for encryption. You should be using TLS v1.2+.
 		
-Note: that setting *minimum_protocol_version = "TLSv1.2_2021"* is only possible when *cloudfront_default_certificate* is false (eg. you are not using the cloudfront.net domain name) and *ssl_support_method* is *sni-only*. 
+Note: that setting *minimum_protocol_version = "TLSv1.2_2021"* is only possible when *cloudfront_default_certificate* is false (eg. you are not using the cloudfront.net domain name). 
 If *cloudfront_default_certificate* is true then the Cloudfront API will only allow setting *minimum_protocol_version = "TLSv1"*, and setting it to any other value will result in a perpetual diff in your *terraform plan*'s. 
 The only option when using the cloudfront.net domain name is to ignore this rule.`,
 		Links: []string{
@@ -45,7 +45,6 @@ The only option when using the cloudfront.net domain name is to ignore this rule
 		for _, dist := range s.AWS.Cloudfront.Distributions {
 			vc := dist.ViewerCertificate
 			if vc.CloudfrontDefaultCertificate.IsFalse() &&
-				vc.SSLSupportMethod.EqualTo("sni-only") &&
 				vc.MinimumProtocolVersion.NotEqualTo(cloudfront.ProtocolVersionTLS1_2) {
 				results.Add(
 					"Distribution allows unencrypted communications.",

--- a/checks/cloud/aws/cloudfront/use_secure_tls_policy.tf.go
+++ b/checks/cloud/aws/cloudfront/use_secure_tls_policy.tf.go
@@ -4,7 +4,7 @@ var terraformUseSecureTlsPolicyGoodExamples = []string{
 	`
  resource "aws_cloudfront_distribution" "good_example" {
    viewer_certificate {
-     cloudfront_default_certificate = aws_acm_certificate.example.arn
+     cloudfront_default_certificate = false
      minimum_protocol_version = "TLSv1.2_2021"
    }
  }
@@ -15,7 +15,7 @@ var terraformUseSecureTlsPolicyBadExamples = []string{
 	`
  resource "aws_cloudfront_distribution" "bad_example" {
    viewer_certificate {
-     cloudfront_default_certificate = aws_acm_certificate.example.arn
+     cloudfront_default_certificate = false
      minimum_protocol_version = "TLSv1.0"
    }
  }

--- a/checks/cloud/aws/cloudfront/use_secure_tls_policy_test.go
+++ b/checks/cloud/aws/cloudfront/use_secure_tls_policy_test.go
@@ -80,7 +80,7 @@ func TestCheckUseSecureTlsPolicy(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: true,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
SSLSupportMethod only restricts the minimum protocol version, so we don't need to check this.

Ref:
- https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ViewerCertificate.html