### PR TITLE
fix(kubernetes): fix the KSV001 check

### DIFF
--- a/checks/kubernetes/pss/restricted/2_can_elevate_its_own_privileges.rego
+++ b/checks/kubernetes/pss/restricted/2_can_elevate_its_own_privileges.rego
@@ -42,9 +42,8 @@ getNoPrivilegeEscalationContainers[container] {
 # getPrivilegeEscalationContainers returns the names of all containers which have
 # securityContext.allowPrivilegeEscalation set to true or not set.
 getPrivilegeEscalationContainers[container] {
-	containerName := kubernetes.containers[_].name
-	not getNoPrivilegeEscalationContainers[containerName]
 	container := kubernetes.containers[_]
+	not getNoPrivilegeEscalationContainers[container.name]
 }
 
 deny[res] {

--- a/checks/kubernetes/pss/restricted/2_can_elevate_its_own_privileges_test.rego
+++ b/checks/kubernetes/pss/restricted/2_can_elevate_its_own_privileges_test.rego
@@ -60,3 +60,34 @@ test_allow_privilege_escalation_set_to_true_denied {
 	count(r) == 1
 	r[_].msg == "Container 'hello' of Pod 'hello-privilege-escalation' should set 'securityContext.allowPrivilegeEscalation' to false"
 }
+
+test_allow_privilege_escalation_multiple_containers {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-privilege-escalation"},
+		"spec": {"containers": [
+			{
+				"command": [
+					"sh",
+					"-c",
+					"echo 'Hello' && sleep 1h",
+				],
+				"image": "busybox",
+				"name": "hello",
+				"securityContext": {"allowPrivilegeEscalation": true},
+			},
+			{
+				"command": [
+					"sh",
+					"-c",
+					"echo 'Hello' && sleep 1h",
+				],
+				"image": "busybox",
+				"name": "hello2",
+				"securityContext": {"allowPrivilegeEscalation": false},
+			},
+		]},
+	}
+	count(r) == 1
+}


### PR DESCRIPTION
The rule was applied to all containers if at least one container had the `allowPrivilegeEscalation` parameter.

Fixes https://github.com/aquasecurity/trivy/issues/6232