### PR TITLE
feat: add DeploymentConfig support

### DIFF
--- a/checks/kubernetes/advanced/default_namespace_should_not_be_used.rego
+++ b/checks/kubernetes/advanced/default_namespace_should_not_be_used.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/advanced/optional/capabilities_no_drop_at_least_one.rego
+++ b/checks/kubernetes/advanced/optional/capabilities_no_drop_at_least_one.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/advanced/optional/manages_etc_hosts.rego
+++ b/checks/kubernetes/advanced/optional/manages_etc_hosts.rego
@@ -18,6 +18,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/advanced/optional/uses_untrusted_azure_registry.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_azure_registry.rego
@@ -18,6 +18,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/advanced/optional/uses_untrusted_ecr_registry.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_ecr_registry.rego
@@ -18,6 +18,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/advanced/optional/uses_untrusted_gcr_registry.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_gcr_registry.rego
@@ -18,6 +18,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/advanced/optional/uses_untrusted_public_registries.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_public_registries.rego
@@ -18,6 +18,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/CPU_not_limited.rego
+++ b/checks/kubernetes/general/CPU_not_limited.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/CPU_requests_not_specified.rego
+++ b/checks/kubernetes/general/CPU_requests_not_specified.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/SYS_ADMIN_capability.rego
+++ b/checks/kubernetes/general/SYS_ADMIN_capability.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/SYS_MODULE_capability.rego
+++ b/checks/kubernetes/general/SYS_MODULE_capability.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/capabilities_no_drop_all.rego
+++ b/checks/kubernetes/general/capabilities_no_drop_all.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/default_security_context.rego
+++ b/checks/kubernetes/general/default_security_context.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/file_system_not_read_only.rego
+++ b/checks/kubernetes/general/file_system_not_read_only.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/memory_not_limited.rego
+++ b/checks/kubernetes/general/memory_not_limited.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/memory_requests_not_specified.rego
+++ b/checks/kubernetes/general/memory_requests_not_specified.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/mounts_docker_socket.rego
+++ b/checks/kubernetes/general/mounts_docker_socket.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/net_raw_capability.rego
+++ b/checks/kubernetes/general/net_raw_capability.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/runs_with_GID_le_10000.rego
+++ b/checks/kubernetes/general/runs_with_GID_le_10000.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/runs_with_UID_le_10000.rego
+++ b/checks/kubernetes/general/runs_with_UID_le_10000.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID.rego
+++ b/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/general/uses_image_tag_latest.rego
+++ b/checks/kubernetes/general/uses_image_tag_latest.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/10_windows_host_process.rego
+++ b/checks/kubernetes/pss/baseline/10_windows_host_process.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/11_seccomp_profile_unconfined.rego
+++ b/checks/kubernetes/pss/baseline/11_seccomp_profile_unconfined.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/12_privileged_ports_binding.rego
+++ b/checks/kubernetes/pss/baseline/12_privileged_ports_binding.rego
@@ -21,6 +21,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/1_host_ipc.rego
+++ b/checks/kubernetes/pss/baseline/1_host_ipc.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/1_host_network.rego
+++ b/checks/kubernetes/pss/baseline/1_host_network.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/1_host_pid.rego
+++ b/checks/kubernetes/pss/baseline/1_host_pid.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/2_privileged.rego
+++ b/checks/kubernetes/pss/baseline/2_privileged.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/3_specific_capabilities_added.rego
+++ b/checks/kubernetes/pss/baseline/3_specific_capabilities_added.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/4_hostpath_volumes_mounted.rego
+++ b/checks/kubernetes/pss/baseline/4_hostpath_volumes_mounted.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/5_access_to_host_ports.rego
+++ b/checks/kubernetes/pss/baseline/5_access_to_host_ports.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/6_apparmor_policy_disabled.rego
+++ b/checks/kubernetes/pss/baseline/6_apparmor_policy_disabled.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/7_selinux_custom_options_set.rego
+++ b/checks/kubernetes/pss/baseline/7_selinux_custom_options_set.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/8_non_default_proc_masks_set.rego
+++ b/checks/kubernetes/pss/baseline/8_non_default_proc_masks_set.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/baseline/9_unsafe_sysctl_options_set.rego
+++ b/checks/kubernetes/pss/baseline/9_unsafe_sysctl_options_set.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/restricted/1_non_core_volume_types.rego
+++ b/checks/kubernetes/pss/restricted/1_non_core_volume_types.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/restricted/2_can_elevate_its_own_privileges.rego
+++ b/checks/kubernetes/pss/restricted/2_can_elevate_its_own_privileges.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/restricted/3_runs_as_root.rego
+++ b/checks/kubernetes/pss/restricted/3_runs_as_root.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set.rego
+++ b/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/checks/kubernetes/pss/restricted/7_Kubernetes_resource_with_disallowed_volumes_mounted.rego
+++ b/checks/kubernetes/pss/restricted/7_Kubernetes_resource_with_disallowed_volumes_mounted.rego
@@ -20,6 +20,7 @@
 #         - kind: replicaset
 #         - kind: replicationcontroller
 #         - kind: deployment
+#         - kind: deploymentconfig
 #         - kind: statefulset
 #         - kind: daemonset
 #         - kind: cronjob

--- a/lib/kubernetes/kubernetes.rego
+++ b/lib/kubernetes/kubernetes.rego
@@ -51,8 +51,15 @@ is_cronjob {
 
 default is_controller = false
 
+api_version = object.apiVersion
+
 is_controller {
 	kind = "Deployment"
+}
+
+is_controller {
+	api_version = "apps.openshift.io/v1"
+	kind = "DeploymentConfig"
 }
 
 is_controller {

--- a/lib/kubernetes/kubernetes_test.rego
+++ b/lib/kubernetes/kubernetes_test.rego
@@ -64,6 +64,42 @@ test_deployment {
 	test_pods[_].spec.containers[_].name == "hello-deployment"
 }
 
+test_deploymentconfig {
+	# spec -> template
+	mock = {
+		"apiVersion": "apps.openshift.io/v1",
+		"kind": "DeploymentConfig",
+		"metadata": {"name": "hello"},
+		"spec": {"template": {"spec": {
+			"containers": [{
+				"command": [
+					"sh",
+					"-c",
+					"echo 'Hello !' && sleep 1h",
+				],
+				"image": "busybox",
+				"name": "hello-deploymentconfig-1",
+			}],
+			"volumes": [
+				{
+					"name": "hello-volume-1",
+					"emptyDir": {},
+				},
+				{
+					"name": "hello-volume-2",
+					"emptyDir": {},
+				},
+			],
+		}}},
+	}
+
+	test_containers := containers with input as mock
+	test_volumes := volumes with input as mock
+
+	test_containers[_].name == "hello-deploymentconfig-1"
+	test_volumes[_].name == "hello-volume-2"
+}
+
 test_stateful_set {
 	# spec -> template
 	test_pods := pods with input as {


### PR DESCRIPTION
Add support for OpenShift's [DeploymentConfig](https://docs.openshift.com/container-platform/4.12/rest_api/workloads_apis/deploymentconfig-apps-openshift-io-v1.html). DeploymentConfig is an enhanced Deployment.

> Deployment Configs define the template for a pod and manages deploying new images or configuration changes. A single deployment configuration is usually analogous to a single micro-service. Can support many different deployment patterns, including full restart, customizable rolling updates, and fully custom behaviors, as well as pre- and post- deployment hooks. Each individual deployment is represented as a replication controller.
> 
> A deployment is "triggered" when its configuration is changed or a tag in an Image Stream is changed. Triggers can be disabled to allow manual control over a deployment. The "strategy" determines how the deployment is carried out and may be changed at any time. The latestVersion field is updated when a new deployment is triggered by any means.